### PR TITLE
master

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     "Colors",
     "CRCB",
     "recase",
-    "riverpod"
+    "riverpod",
+    "Wakelock"
   ]
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(final BuildContext context) {
+    WidgetsFlutterBinding.ensureInitialized();
     RendererBinding.instance.ensureSemantics();
     return ProviderScope(
       child: MaterialApp(

--- a/lib/src/screens/game_screen.dart
+++ b/lib/src/screens/game_screen.dart
@@ -189,7 +189,7 @@ class GameScreenState extends ConsumerState<GameScreen> {
                                 },
                               ),
                               subtitle: CustomText(event.type.name.titleCase),
-                              onLongPress: () => deleteEvent(event),
+                              onTap: () => deleteEvent(event),
                             ),
                           );
                         },

--- a/lib/src/screens/game_screen.dart
+++ b/lib/src/screens/game_screen.dart
@@ -415,6 +415,17 @@ class GameScreenState extends ConsumerState<GameScreen> {
           events.removeWhere(
             (final oldEvent) => oldEvent.id == event.id,
           );
+          // Roll back the server.
+          switch (serveNumber) {
+            case ServeNumber.first:
+              serveNumber = ServeNumber.second;
+              servingPlayer = switch (servingPlayer) {
+                TableEnd.left => TableEnd.right,
+                TableEnd.right => TableEnd.left
+              };
+            case ServeNumber.second:
+              serveNumber = ServeNumber.first;
+          }
           setState(() {});
         },
       );

--- a/lib/src/screens/game_screen.dart
+++ b/lib/src/screens/game_screen.dart
@@ -172,6 +172,7 @@ class GameScreenState extends ConsumerState<GameScreen> {
       ),
     );
     return GameShortcuts(
+      autofocus: false,
       shortcuts: shortcuts,
       child: SimpleScaffold(
         leading: ElevatedButton(

--- a/lib/src/screens/game_screen.dart
+++ b/lib/src/screens/game_screen.dart
@@ -7,7 +7,6 @@ import 'package:backstreets_widgets/util.dart';
 import 'package:backstreets_widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:recase/recase.dart';
 
 import '../constants.dart';
 import '../json/game_event.dart';
@@ -17,6 +16,7 @@ import '../serve_number.dart';
 import '../table_end.dart';
 import '../widgets/custom_text.dart';
 import '../widgets/foul_button.dart';
+import '../widgets/game_event_list_tile.dart';
 import '../widgets/goal_button.dart';
 import '../widgets/player_panel.dart';
 import '../widgets/rename_player.dart';
@@ -179,18 +179,14 @@ class GameScreenState extends ConsumerState<GameScreen> {
                       child: ListView.builder(
                         itemBuilder: (final context, final index) {
                           final event = events[index];
-                          return CommonShortcuts(
-                            deleteCallback: () => deleteEvent(event),
-                            child: ListTile(
-                              title: CustomText(
-                                switch (event.tableEnd) {
-                                  TableEnd.left => leftPlayerName,
-                                  TableEnd.right => rightPlayerName,
-                                },
-                              ),
-                              subtitle: CustomText(event.type.name.titleCase),
-                              onTap: () => deleteEvent(event),
-                            ),
+                          final playerName = switch (event.tableEnd) {
+                            TableEnd.left => leftPlayerName,
+                            TableEnd.right => rightPlayerName,
+                          };
+                          return GameEventListTile(
+                            event: event,
+                            deleteEvent: deleteEvent,
+                            playerName: playerName,
                           );
                         },
                         itemCount: events.length,

--- a/lib/src/screens/select_foul_screen.dart
+++ b/lib/src/screens/select_foul_screen.dart
@@ -11,70 +11,65 @@ import '../widgets/custom_text.dart';
 class SelectFoulScreen extends ConsumerWidget {
   /// Create an instance.
   const SelectFoulScreen({
+    required this.fouls,
     required this.onDone,
     super.key,
   });
+
+  /// The fouls to show.
+  final List<GameEventType> fouls;
 
   /// The function to call when a foul has been selected.
   final ValueChanged<GameEventType> onDone;
 
   /// Build the widget.
   @override
-  Widget build(final BuildContext context, final WidgetRef ref) {
-    final fouls = GameEventType.values
-        .where((final type) => type != GameEventType.goal)
-        .toList()
-      ..sort(
-        (final a, final b) =>
-            a.name.toLowerCase().compareTo(b.name.toLowerCase()),
-      );
-    return Cancel(
-      child: SimpleScaffold(
-        title: 'Select Foul',
-        body: OrientationBuilder(
-          builder: (final context, final orientation) => ListView.builder(
-            itemBuilder: (final context, final index) {
-              final foul = fouls[index];
-              final foulName = foul.name.titleCase;
-              switch (orientation) {
-                case Orientation.portrait:
-                  return ListTile(
-                    autofocus: index == 0,
-                    title: CustomText(foulName),
-                    onTap: () => activateFoul(context, foul),
-                  );
-                case Orientation.landscape:
-                  return Semantics(
-                    label: foulName,
-                    child: FocusableActionDetector(
+  Widget build(final BuildContext context, final WidgetRef ref) => Cancel(
+        child: SimpleScaffold(
+          title: 'Select Foul',
+          body: OrientationBuilder(
+            builder: (final context, final orientation) => ListView.builder(
+              itemBuilder: (final context, final index) {
+                final foul = fouls[index];
+                final foulName = foul.name.titleCase;
+                switch (orientation) {
+                  case Orientation.portrait:
+                    return ListTile(
                       autofocus: index == 0,
-                      actions: {
-                        ActivateIntent: CallbackAction(
-                          onInvoke: (final intent) =>
-                              activateFoul(context, foul),
-                        ),
-                      },
-                      child: GestureDetector(
-                        onTap: () => activateFoul(context, foul),
-                        child: Card(
-                          child: CustomText(foulName),
+                      title: CustomText(foulName),
+                      onTap: () => activateFoul(context, foul),
+                    );
+                  case Orientation.landscape:
+                    return Semantics(
+                      label: foulName,
+                      child: FocusableActionDetector(
+                        autofocus: index == 0,
+                        actions: {
+                          ActivateIntent: CallbackAction(
+                            onInvoke: (final intent) =>
+                                activateFoul(context, foul),
+                          ),
+                        },
+                        child: GestureDetector(
+                          onTap: () => activateFoul(context, foul),
+                          child: Card(
+                            child: CustomText(foulName),
+                          ),
                         ),
                       ),
-                    ),
-                  );
-              }
-            },
-            itemCount: fouls.length,
-            scrollDirection: switch (orientation) {
-              Orientation.portrait => Axis.vertical,
-              Orientation.landscape => Axis.horizontal,
-            },
-            shrinkWrap: true,
+                    );
+                }
+              },
+              itemCount: fouls.length,
+              scrollDirection: switch (orientation) {
+                Orientation.portrait => Axis.vertical,
+                Orientation.landscape => Axis.horizontal,
+              },
+              shrinkWrap: true,
+            ),
           ),
         ),
-      ),
-    );
-  }
+      );
 
   /// Activate the given [foul].
   void activateFoul(final BuildContext context, final GameEventType foul) {

--- a/lib/src/widgets/foul_button.dart
+++ b/lib/src/widgets/foul_button.dart
@@ -11,6 +11,7 @@ class FoulButton extends StatelessWidget {
   /// Create an instance.
   const FoulButton({
     required this.playerName,
+    required this.fouls,
     required this.addEvent,
     super.key,
   });
@@ -18,36 +19,32 @@ class FoulButton extends StatelessWidget {
   /// The name of the player in question.
   final String playerName;
 
+  /// The fouls to show.
+  final List<GameEventType> fouls;
+
   /// The function to call to add an event.
   final void Function(GameEventType eventType) addEvent;
 
   /// Build the widget.
   @override
-  Widget build(final BuildContext context) {
-    final fouls = GameEventType.values
-        .where((final type) => type != GameEventType.goal)
-        .toList()
-      ..sort(
-        (final a, final b) =>
-            a.name.toLowerCase().compareTo(b.name.toLowerCase()),
-      );
-    return Semantics(
-      customSemanticsActions: {
-        for (final foul in fouls)
-          CustomSemanticsAction(label: foul.name.titleCase): () =>
-              addEvent(foul),
-      },
-      child: ElevatedButton(
-        onPressed: () => context.pushWidgetBuilder(
-          (final context) => SelectFoulScreen(
-            onDone: addEvent,
+  Widget build(final BuildContext context) => Semantics(
+        customSemanticsActions: {
+          for (final foul in fouls)
+            CustomSemanticsAction(label: foul.name.titleCase): () =>
+                addEvent(foul),
+        },
+        key: ValueKey(fouls.join(', ')),
+        child: ElevatedButton(
+          onPressed: () => context.pushWidgetBuilder(
+            (final context) => SelectFoulScreen(
+              fouls: fouls,
+              onDone: addEvent,
+            ),
+          ),
+          child: Icon(
+            Icons.warning,
+            semanticLabel: '$playerName Foul',
           ),
         ),
-        child: Icon(
-          Icons.warning,
-          semanticLabel: '$playerName Foul',
-        ),
-      ),
-    );
-  }
+      );
 }

--- a/lib/src/widgets/game_event_list_tile.dart
+++ b/lib/src/widgets/game_event_list_tile.dart
@@ -1,0 +1,43 @@
+import 'package:backstreets_widgets/widgets.dart';
+import 'package:flutter/material.dart';
+
+import '../json/game_event.dart';
+import 'custom_text.dart';
+import 'game_event_text.dart';
+
+/// A list tile to show a game [event].
+class GameEventListTile extends StatelessWidget {
+  /// Create an instance.
+  const GameEventListTile({
+    required this.event,
+    required this.deleteEvent,
+    this.playerName,
+    super.key,
+  });
+
+  /// The event to show.
+  final GameEvent event;
+
+  /// The function to call to delete [event].
+  final void Function(GameEvent event) deleteEvent;
+
+  /// The player name to show.
+  ///
+  /// If [playerName] is `null`, the [ListTile] will use [event] to create its
+  /// `title`.
+  final String? playerName;
+
+  /// Build the widget.
+  @override
+  Widget build(final BuildContext context) {
+    final name = playerName;
+    return CommonShortcuts(
+      deleteCallback: () => deleteEvent(event),
+      child: ListTile(
+        title: name == null ? GameEventText(event: event) : CustomText(name),
+        subtitle: name == null ? null : GameEventText(event: event),
+        onTap: () => deleteEvent(event),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/game_event_text.dart
+++ b/lib/src/widgets/game_event_text.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:recase/recase.dart';
+
+import '../json/game_event.dart';
+import 'custom_text.dart';
+
+/// A [CustomText] widget which shows a game [event].
+class GameEventText extends StatelessWidget {
+  /// Create an instance.
+  const GameEventText({
+    required this.event,
+    super.key,
+  });
+
+  /// The event to show.
+  final GameEvent event;
+
+  /// Build the widget.
+  @override
+  Widget build(final BuildContext context) =>
+      CustomText(event.type.name.titleCase);
+}

--- a/lib/src/widgets/player_panel.dart
+++ b/lib/src/widgets/player_panel.dart
@@ -72,8 +72,7 @@ class PlayerPanel extends StatelessWidget {
                   deleteCallback: () => deleteEvent(event),
                   child: ListTile(
                     title: CustomText(event.type.name.titleCase),
-                    onTap: () {},
-                    onLongPress: () => deleteEvent(event),
+                    onTap: () => deleteEvent(event),
                   ),
                 ),
               ),

--- a/lib/src/widgets/player_panel.dart
+++ b/lib/src/widgets/player_panel.dart
@@ -15,6 +15,7 @@ import 'rename_player.dart';
 class PlayerPanel extends StatelessWidget {
   /// Create an instance.
   const PlayerPanel({
+    required this.fouls,
     required this.name,
     required this.tableEnd,
     required this.events,
@@ -23,6 +24,9 @@ class PlayerPanel extends StatelessWidget {
     required this.deleteEvent,
     super.key,
   });
+
+  /// The fouls to use.
+  final List<GameEventType> fouls;
 
   /// The name of the player.
   final String name;
@@ -47,7 +51,11 @@ class PlayerPanel extends StatelessWidget {
   Widget build(final BuildContext context) {
     final buttons = [
       GoalButton(playerName: name, addEvent: addEvent),
-      FoulButton(playerName: name, addEvent: addEvent),
+      FoulButton(
+        fouls: fouls,
+        playerName: name,
+        addEvent: addEvent,
+      ),
     ];
     return Column(
       crossAxisAlignment: switch (tableEnd) {

--- a/lib/src/widgets/player_panel.dart
+++ b/lib/src/widgets/player_panel.dart
@@ -1,13 +1,13 @@
 import 'package:backstreets_widgets/extensions.dart';
 import 'package:backstreets_widgets/widgets.dart';
 import 'package:flutter/material.dart';
-import 'package:recase/recase.dart';
 
 import '../json/game_event.dart';
 import '../json/game_event_type.dart';
 import '../table_end.dart';
 import 'custom_text.dart';
 import 'foul_button.dart';
+import 'game_event_list_tile.dart';
 import 'goal_button.dart';
 import 'rename_player.dart';
 
@@ -70,9 +70,9 @@ class PlayerPanel extends StatelessWidget {
               ...events.reversed.map(
                 (final event) => CommonShortcuts(
                   deleteCallback: () => deleteEvent(event),
-                  child: ListTile(
-                    title: CustomText(event.type.name.titleCase),
-                    onTap: () => deleteEvent(event),
+                  child: GameEventListTile(
+                    event: event,
+                    deleteEvent: deleteEvent,
                   ),
                 ),
               ),

--- a/lib/src/widgets/rename_player.dart
+++ b/lib/src/widgets/rename_player.dart
@@ -1,9 +1,11 @@
-import 'package:backstreets_widgets/widgets.dart';
+import 'package:backstreets_widgets/screens.dart';
 import 'package:flutter/material.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
 
+import 'custom_text.dart';
+
 /// A widget for renaming a player.
-class RenamePlayer extends StatelessWidget {
+class RenamePlayer extends StatefulWidget {
   /// Create an instance.
   const RenamePlayer({
     required this.name,
@@ -17,16 +19,65 @@ class RenamePlayer extends StatelessWidget {
   /// The function to call with the new name.
   final void Function(String name) onChanged;
 
+  @override
+  State<RenamePlayer> createState() => _RenamePlayerState();
+}
+
+class _RenamePlayerState extends State<RenamePlayer> {
+  /// The form key to use.
+  late final GlobalKey<FormState> formKey;
+
+  /// The controller to use.
+  late final TextEditingController controller;
+
+  /// Initialise state.
+  @override
+  void initState() {
+    super.initState();
+    formKey = GlobalKey();
+    controller = TextEditingController(text: widget.name);
+    controller.selection =
+        TextSelection(baseOffset: 0, extentOffset: controller.text.length);
+  }
+
+  /// Dispose of the widget.
+  @override
+  void dispose() {
+    super.dispose();
+    controller.dispose();
+  }
+
   /// Build the widget.
   @override
-  Widget build(final BuildContext builderContext) => GetText(
-        onDone: (final value) {
-          Navigator.pop(builderContext);
-          onChanged(value);
-        },
-        labelText: 'Player name',
-        text: name,
-        title: 'Rename Player',
-        validator: FormBuilderValidators.required(),
+  Widget build(final BuildContext builderContext) => PopScope(
+        onPopInvokedWithResult: (final didPop, final result) => submitForm(),
+        child: SimpleScaffold(
+          title: 'Rename Player',
+          body: Center(
+            child: Form(
+              key: formKey,
+              child: TextFormField(
+                autofocus: true,
+                controller: controller,
+                decoration: const InputDecoration(
+                  label: CustomText('Player name'),
+                  helperText: 'This will be the new name for the player',
+                ),
+                validator: FormBuilderValidators.required(
+                  errorText: 'The player name cannot be empty',
+                ),
+                onFieldSubmitted: (final _) => Navigator.pop(context),
+              ),
+            ),
+          ),
+        ),
       );
+
+  /// Submit the form.
+  void submitForm() {
+    if (formKey.currentState?.validate() ?? false) {
+      final newName = controller.text;
+      widget.onChanged(newName);
+    }
+  }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import package_info_plus
 import shared_preferences_foundation
+import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.5.0-180.3.beta <4.0.0"
 
 dependencies:
-  backstreets_widgets: ^0.13.0
+  backstreets_widgets: ^0.15.0
   cupertino_icons: ^1.0.8
   flutter:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   riverpod_annotation: ^2.3.5
   shared_preferences: ^2.2.3
   uuid: ^4.4.2
+  wakelock_plus: ^1.1.6
 
 dev_dependencies:
   build_runner: ^2.4.11


### PR DESCRIPTION
- Allow changing player names.
- Shrunk event code.
- Add actions to the foul button.
- Depend on `custom_lint`.
- Sort fouls alphabetically.
- Make the serve announcements a live region.
- Sort fouls alphabetically.
- Allow escape key to exit foul selection.
- Label fouls properly.
- Add keyboard shortcuts.
- Allow control b to change ends.
- Added a portrait view.
- Add portrait mode.
- Show the correct events.
- Include player names in button labels.
- Added some trailing commas.
- switch serves every time the point ends.
- Tap events to delete them.
- Roll back server when removing an event.
- Allow events to be deleted with a tap in portrait mode.
- Added the `GameEventText` widget.
- Update the `RenamePlayer` widget.
- Try to order fouls by repitition.
- Don't autofocus the `GameShortcut` `FocusNode`.
- Update the `backstreets_widgets` dependency.
